### PR TITLE
Improve screen_name option and handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run bundle, the project should need:
 * Sim. Invoices - 100%
 * Credit Notes  - 100%
 * Purch. Orders - 100%
- 
+
 ## Documentation
 
 We've included docs for all methods. Refer to the doc folder and client section.
@@ -51,9 +51,9 @@ We've included docs for all methods. Refer to the doc folder and client section.
 If using from inside a rails project use:
 
     require 'invoicexpress'
- 
+
     client = Invoicexpress::Client.new(
-      :screen_name => "yourusername",
+      :account_name => "yourusername",
       :api_key     => "yourapikey"
     )
 

--- a/doc/yard/Invoicexpress/Configuration.html
+++ b/doc/yard/Invoicexpress/Configuration.html
@@ -5,9 +5,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>
   Module: Invoicexpress::Configuration
-  
+
     &mdash; Documentation by YARD 0.8.5
-  
+
 </title>
 
   <link rel="stylesheet" href="../css/style.css" type="text/css" media="screen" charset="utf-8" />
@@ -30,33 +30,33 @@
   <body>
     <div id="header">
       <div id="menu">
-  
+
     <a href="../_index.html">Index (C)</a> &raquo;
     <span class='title'><span class='object_link'><a href="../Invoicexpress.html" title="Invoicexpress (module)">Invoicexpress</a></span></span>
-     &raquo; 
+     &raquo;
     <span class="title">Configuration</span>
-  
+
 
   <div class="noframes"><span class="title">(</span><a href="." target="_top">no frames</a><span class="title">)</span></div>
 </div>
 
       <div id="search">
-  
+
     <a class="full_list_link" id="class_list_link"
         href="../class_list.html">
       Class List
     </a>
-  
+
     <a class="full_list_link" id="method_list_link"
         href="../method_list.html">
       Method List
     </a>
-  
+
     <a class="full_list_link" id="file_list_link"
         href="../file_list.html">
       File List
     </a>
-  
+
 </div>
       <div class="clear"></div>
     </div>
@@ -64,65 +64,64 @@
     <iframe id="search_frame"></iframe>
 
     <div id="content"><h1>Module: Invoicexpress::Configuration
-  
-  
-  
+
+
+
 </h1>
 
 <dl class="box">
-  
-  
-    
-  
-    
-  
-  
+
+
+
+
+
+
+
     <dt class="r1">Included in:</dt>
     <dd class="r1"><span class='object_link'><a href="../Invoicexpress.html" title="Invoicexpress (module)">Invoicexpress</a></span></dd>
-    
-  
-  
+
+
+
     <dt class="r2 last">Defined in:</dt>
     <dd class="r2 last">lib/invoicexpress/configuration.rb</dd>
-  
+
 </dl>
 <div class="clear"></div>
 
 
   <h2>Constant Summary</h2>
-  
+
     <dl class="constants">
-      
+
         <dt id="VALID_OPTIONS_KEYS-constant" class="">VALID_OPTIONS_KEYS =
-          
+
         </dt>
         <dd><pre class="code"><span class='lbracket'>[</span>
   <span class='symbol'>:adapter</span><span class='comma'>,</span>
   <span class='symbol'>:faraday_config_block</span><span class='comma'>,</span>
   <span class='symbol'>:api_endpoint</span><span class='comma'>,</span>
-  <span class='symbol'>:screen_name</span><span class='comma'>,</span>
+  <span class='symbol'>:account_name</span><span class='comma'>,</span>
   <span class='symbol'>:proxy</span><span class='comma'>,</span>
   <span class='symbol'>:api_key</span><span class='comma'>,</span>
   <span class='symbol'>:user_agent</span>
 <span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
-      
+
         <dt id="DEFAULT_ADAPTER-constant" class="">DEFAULT_ADAPTER =
-          
+
         </dt>
         <dd><pre class="code"><span class='const'>Faraday</span><span class='period'>.</span><span class='id identifier rubyid_default_adapter'>default_adapter</span></pre></dd>
-      
+
         <dt id="DEFAULT_API_ENDPOINT-constant" class="">DEFAULT_API_ENDPOINT =
-          
+
         </dt>
         <dd><pre class="code"><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>'</span><span class='tstring_content'>INVOICEXPRESS_API_ENDPOINT</span><span class='tstring_end'>'</span></span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='tstring'><span class='tstring_beg'>'</span><span class='tstring_content'>https://%s.invoicexpress.net/</span><span class='tstring_end'>'</span></span></pre></dd>
-      
+
         <dt id="DEFAULT_USER_AGENT-constant" class="">DEFAULT_USER_AGENT =
-          
+
         </dt>
         <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Invoicexpress Ruby Gem </span><span class='embexpr_beg'>#{</span><span class='const'>Invoicexpress</span><span class='op'>::</span><span class='const'>VERSION</span><span class='rbrace'>}</span><span class='tstring_end'>&quot;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
-      
+
     </dl>
-  
 
 
 
@@ -524,14 +523,14 @@
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_api_endpoint'>api_endpoint</span> <span class='op'>=</span> <span class='const'>DEFAULT_API_ENDPOINT</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_user_agent'>user_agent</span>   <span class='op'>=</span> <span class='const'>DEFAULT_USER_AGENT</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_api_key'>api_key</span>      <span class='op'>=</span> <span class='kw'>nil</span>
-  <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_screen_name'>screen_name</span>  <span class='op'>=</span> <span class='kw'>nil</span>
+  <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_account_name'>account_name</span>  <span class='op'>=</span> <span class='kw'>nil</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_proxy'>proxy</span>        <span class='op'>=</span> <span class='kw'>nil</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
 </table>
 </div>
-    
+
   </div>
 
 </div>

--- a/doc/yard/file.README.html
+++ b/doc/yard/file.README.html
@@ -112,7 +112,7 @@ And pretzels!</p>
     require &#8216;invoicexpress&#8217;</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='const'>Invoicexpress</span><span class='op'>::</span><span class='const'>Client</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span>
-  <span class='symbol'>:screen_name</span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>yourusername</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span>
+  <span class='symbol'>:account_name</span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>yourusername</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span>
   <span class='symbol'>:api_key</span>     <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>yourapikey</span><span class='tstring_end'>&quot;</span></span>
 <span class='rparen'>)</span>
 

--- a/doc/yard/index.html
+++ b/doc/yard/index.html
@@ -112,7 +112,7 @@ And pretzels!</p>
     require &#8216;invoicexpress&#8217;</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='const'>Invoicexpress</span><span class='op'>::</span><span class='const'>Client</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span>
-  <span class='symbol'>:screen_name</span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>yourusername</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span>
+  <span class='symbol'>:account_name</span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>yourusername</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span>
   <span class='symbol'>:api_key</span>     <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>yourapikey</span><span class='tstring_end'>&quot;</span></span>
 <span class='rparen'>)</span>
 

--- a/lib/invoicexpress/client.rb
+++ b/lib/invoicexpress/client.rb
@@ -51,6 +51,6 @@ module Invoicexpress
     include Invoicexpress::Client::DebitNotes
     include Invoicexpress::Client::CreditNotes
     include Invoicexpress::Client::SimplifiedInvoices
-    
+
   end
 end

--- a/lib/invoicexpress/client/invoices.rb
+++ b/lib/invoicexpress/client/invoices.rb
@@ -3,7 +3,7 @@ require 'invoicexpress/models'
 module Invoicexpress
   class Client
     module Invoices
-      
+
       # Returns all your invoices
       #
       # @option options [Integer] page (1) You can ask a specific page of invoices
@@ -106,8 +106,6 @@ module Invoicexpress
       def invoice_email(invoice_id, message, options={})
         email_invoice(invoice_id, message, options)
       end
-
-
     end
   end
 end

--- a/lib/invoicexpress/configuration.rb
+++ b/lib/invoicexpress/configuration.rb
@@ -7,7 +7,7 @@ module Invoicexpress
       :adapter,
       :faraday_config_block,
       :api_endpoint,
-      :screen_name,
+      :account_name,
       :proxy,
       :api_key,
       :user_agent
@@ -44,7 +44,7 @@ module Invoicexpress
       self.api_endpoint = DEFAULT_API_ENDPOINT
       self.user_agent   = DEFAULT_USER_AGENT
       self.api_key      = nil
-      self.screen_name  = nil
+      self.account_name  = nil
       self.proxy        = nil
     end
   end

--- a/lib/invoicexpress/configuration.rb
+++ b/lib/invoicexpress/configuration.rb
@@ -8,6 +8,7 @@ module Invoicexpress
       :faraday_config_block,
       :api_endpoint,
       :account_name,
+      :screen_name,
       :proxy,
       :api_key,
       :user_agent
@@ -44,7 +45,8 @@ module Invoicexpress
       self.api_endpoint = DEFAULT_API_ENDPOINT
       self.user_agent   = DEFAULT_USER_AGENT
       self.api_key      = nil
-      self.account_name  = nil
+      self.account_name = nil
+      self.screen_name  = nil
       self.proxy        = nil
     end
   end

--- a/lib/invoicexpress/connection.rb
+++ b/lib/invoicexpress/connection.rb
@@ -35,6 +35,5 @@ module Invoicexpress
       connection.headers[:user_agent] = user_agent
       connection
     end
-
   end
 end

--- a/lib/invoicexpress/error.rb
+++ b/lib/invoicexpress/error.rb
@@ -38,7 +38,7 @@ module Invoicexpress
     private
 
     def build_error_message
-      return nil  if @response.nil?
+      return nil if @response.nil?
 
       message = if response_body
         if response_body.respond_to?(:errors)
@@ -65,4 +65,7 @@ module Invoicexpress
 
   # Raised when Invoicexpress server goes dark (500 HTTP status code)
   class InternalServerError < Error; end
+
+  # Raised when Invoicexpress server address could not be resolved
+  class BadAddress < Error; end
 end

--- a/lib/invoicexpress/request.rb
+++ b/lib/invoicexpress/request.rb
@@ -57,7 +57,13 @@ module Invoicexpress
       end
 
       response
-    end
+    rescue Faraday::ConnectionFailed => e
+      unless e.message.match(/getaddrinfo/).nil?
+        raise Invoicexpress::BadAddress.new,
+          "Did you forget to set your account_name? Error: #{e.message}"
+      end
 
+      raise e
+    end
   end
 end

--- a/lib/invoicexpress/request.rb
+++ b/lib/invoicexpress/request.rb
@@ -34,7 +34,7 @@ module Invoicexpress
 
     def request(method, path, options={})
       token = options.delete(:api_key)  || api_key
-      url   = options.delete(:endpoint) || (api_endpoint % account_name)
+      url   = options.delete(:endpoint) || (api_endpoint % account_domain)
       klass = options.delete(:klass) || raise(ArgumentError, "Need a HappyMapper class to parse")
 
       conn_options = {
@@ -64,6 +64,10 @@ module Invoicexpress
       end
 
       raise e
+    end
+
+    def account_domain
+      account_name || screen_name
     end
   end
 end

--- a/lib/invoicexpress/request.rb
+++ b/lib/invoicexpress/request.rb
@@ -22,8 +22,8 @@ module Invoicexpress
     end
 
     private
-    
-    # Executes the request, checking if ti was successful
+
+    # Executes the request, checking if it was successful
     #
     # @return [Boolean] True on success, false otherwise
     def boolean_from_response(method, path, options={})
@@ -34,7 +34,7 @@ module Invoicexpress
 
     def request(method, path, options={})
       token = options.delete(:api_key)  || api_key
-      url   = options.delete(:endpoint) || (api_endpoint % screen_name)
+      url   = options.delete(:endpoint) || (api_endpoint % account_name)
       klass = options.delete(:klass) || raise(ArgumentError, "Need a HappyMapper class to parse")
 
       conn_options = {

--- a/spec/invoicexpress/client/charts_spec.rb
+++ b/spec/invoicexpress/client/charts_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 describe Invoicexpress::Client::Charts do
 
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".invoicing_chart" do
@@ -29,10 +29,10 @@ describe Invoicexpress::Client::Charts do
       chart.graphs.count.should ==4
       #count values
       chart.graphs.first.values.count.should ==7
-      
+
     end
   end
-  
+
   describe ".top_clients" do
     it "Returns the top 5 clients." do
        stub_get("/api/charts/top-clients.xml").
@@ -43,7 +43,7 @@ describe Invoicexpress::Client::Charts do
        chart.clients.size.should ==1
     end
   end
-  
+
   describe ".top_debtors" do
     it "Returns the top 5 debtors." do
        stub_get("/api/charts/top-debtors.xml").

--- a/spec/invoicexpress/client/clients_spec.rb
+++ b/spec/invoicexpress/client/clients_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 describe Invoicexpress::Client::Clients do
 
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".clients" do

--- a/spec/invoicexpress/client/credit_notes_spec.rb
+++ b/spec/invoicexpress/client/credit_notes_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 describe Invoicexpress::Client::CreditNotes do
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".credit_notes" do
@@ -21,7 +21,7 @@ describe Invoicexpress::Client::CreditNotes do
       stub_post("/credit_notes.xml").
         to_return(xml_response("credit_notes.create.xml"))
 
-      
+
       cnote = Invoicexpress::Models::CreditNote.new(
         :date => Date.new(2013, 5, 1),
         :due_date => Date.new(2013, 6, 1),
@@ -84,7 +84,7 @@ describe Invoicexpress::Client::CreditNotes do
       expect { cnote = @client.update_credit_note_state(1423940, state) }.to_not raise_error
     end
   end
- 
+
   describe ".credit_note_mail" do
     it "sends the credit note through email" do
       stub_put("/credit_notes/1423940/email-document.xml").

--- a/spec/invoicexpress/client/invoices_spec.rb
+++ b/spec/invoicexpress/client/invoices_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 describe Invoicexpress::Client::Invoices do
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".invoices" do
@@ -21,7 +21,7 @@ describe Invoicexpress::Client::Invoices do
       stub_post("/invoices.xml").
         to_return(xml_response("invoices.create.xml"))
 
-      
+
       object = Invoicexpress::Models::Invoice.new(
         :date => Date.new(2013, 6, 18),
         :due_date => Date.new(2013, 6, 18),
@@ -79,7 +79,7 @@ describe Invoicexpress::Client::Invoices do
       }.to raise_error(ArgumentError)
     end
   end
- 
+
   describe ".update_invoice_state" do
     it "updates the state" do
       stub_put("/invoices/1503698/change-state.xml").
@@ -91,7 +91,7 @@ describe Invoicexpress::Client::Invoices do
       expect { @client.update_invoice_state(1503698, state) }.to_not raise_error
     end
   end
- 
+
   describe ".email_invoice" do
     it "sends the invoice through email" do
       stub_put("/invoice/1503698/email-invoice.xml").

--- a/spec/invoicexpress/client/purchase_orders_spec.rb
+++ b/spec/invoicexpress/client/purchase_orders_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 describe Invoicexpress::Client::PurchaseOrders do
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".purchase_orders" do
@@ -20,7 +20,7 @@ describe Invoicexpress::Client::PurchaseOrders do
     it "creates a new purchase order" do
       stub_post("/purchase_orders.xml").
         to_return(xml_response("po.create.xml"))
-            
+
       object = Invoicexpress::Models::PurchaseOrder.new(
         :date => Date.new(2013, 5, 30),
         :due_date => Date.new(2013, 8, 8),
@@ -82,7 +82,7 @@ describe Invoicexpress::Client::PurchaseOrders do
       }.to raise_error(ArgumentError)
     end
   end
- 
+
 
   describe ".update_purchase_order_state" do
     it "updates the state" do
@@ -96,7 +96,7 @@ describe Invoicexpress::Client::PurchaseOrders do
       expect { item = @client.update_purchase_order_state(1430338, state) }.to_not raise_error
     end
   end
- 
+
   describe ".simplified_invoice_mail" do
     it "sends the invoice through email" do
       stub_put("/purchase_orders/1430338/email-document.xml").

--- a/spec/invoicexpress/client/schedules_spec.rb
+++ b/spec/invoicexpress/client/schedules_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 describe Invoicexpress::Client::Schedules do
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".schedules" do

--- a/spec/invoicexpress/client/sequences_spec.rb
+++ b/spec/invoicexpress/client/sequences_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 describe Invoicexpress::Client::Sequences do
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".sequences" do

--- a/spec/invoicexpress/client/simplified_invoices_spec.rb
+++ b/spec/invoicexpress/client/simplified_invoices_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 describe Invoicexpress::Client::SimplifiedInvoices do
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".simplified_invoices" do
@@ -21,7 +21,7 @@ describe Invoicexpress::Client::SimplifiedInvoices do
       stub_post("/simplified_invoices.xml").
         to_return(xml_response("simplified_invoices.create.xml"))
 
-      
+
       object = Invoicexpress::Models::SimplifiedInvoice.new(
         :date => Date.new(2013, 5, 1),
         :due_date => Date.new(2013, 6, 1),
@@ -84,7 +84,7 @@ describe Invoicexpress::Client::SimplifiedInvoices do
       }.to raise_error(ArgumentError)
     end
   end
- 
+
   describe ".update_simplified_invoice_state" do
     it "updates the state" do
       stub_put("/simplified_invoices/1425061/change-state.xml").
@@ -96,7 +96,7 @@ describe Invoicexpress::Client::SimplifiedInvoices do
       expect { item = @client.update_simplified_invoice_state(1425061, state) }.to_not raise_error
     end
   end
- 
+
   describe ".simplified_invoice_mail" do
     it "sends the invoice through email" do
       stub_put("/simplified_invoices/1425061/email-document.xml").

--- a/spec/invoicexpress/client/taxes_spec.rb
+++ b/spec/invoicexpress/client/taxes_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 describe Invoicexpress::Client::Taxes do
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".taxes" do

--- a/spec/invoicexpress/client/users_spec.rb
+++ b/spec/invoicexpress/client/users_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 describe Invoicexpress::Client::Clients do
 
   before do
-    @client = Invoicexpress::Client.new(:screen_name => "thinkorangeteste")
+    @client = Invoicexpress::Client.new(:account_name => "thinkorangeteste")
   end
 
   describe ".login" do
@@ -27,12 +27,12 @@ describe Invoicexpress::Client::Clients do
       list.first.name.should == "thinkorangeteste"
     end
   end
-  
+
   describe ".change-account" do
     it "changes the current account to the account id submitted" do
       stub_put("/users/change-account.xml").
         to_return(xml_response("users.change-account.xml"))
-        
+
       expect { cnote = @client.change_account(13233) }.to_not raise_error
     end
   end

--- a/spec/invoicexpress/request_spec.rb
+++ b/spec/invoicexpress/request_spec.rb
@@ -19,6 +19,30 @@ RSpec.describe Invoicexpress::Request do
           Invoicexpress::BadAddress, /forget.+account_name/)
       end
     end
+
+    context 'given a client with options' do
+      let (:client) { Invoicexpress.new options }
+
+      before { stub_request :any, 'https://test.app.invoicexpress.com/' }
+
+      context 'given an account_name' do
+        let (:options) { { account_name: 'test' } }
+
+        it 'sets the correct account subdomain' do
+          subject
+          assert_requested :any, 'https://test.app.invoicexpress.com/', times: 1
+        end
+      end
+
+      context 'given an screen_name' do
+        let (:options) { { screen_name: 'test' } }
+
+        it 'sets the correct account subdomain' do
+          subject
+          assert_requested :any, 'https://test.app.invoicexpress.com/', times: 1
+        end
+      end
+    end
   end
 
   describe '.delete' do

--- a/spec/invoicexpress/request_spec.rb
+++ b/spec/invoicexpress/request_spec.rb
@@ -1,0 +1,48 @@
+require 'helper'
+
+RSpec.describe Invoicexpress::Request do
+  let (:path) { '' }
+  let (:klass) { Class.new { include HappyMapper } }
+
+  shared_examples 'an account_name validator' do
+    context 'given a client with no account_name' do
+      let (:client) { Invoicexpress.new }
+
+      before do
+        stub_request(:any, 'https://.app.invoicexpress.com/')
+          .to_raise(Faraday::ConnectionFailed.new(
+            'getaddrinfo: nodename nor servname provided, or not known'))
+      end
+
+      it 'raises a BadAddress error with a helpful suggestion' do
+        expect { subject }.to raise_error(
+          Invoicexpress::BadAddress, /forget.+account_name/)
+      end
+    end
+  end
+
+  describe '.delete' do
+    subject (:delete) { client.delete path, klass: klass }
+    it_behaves_like 'an account_name validator'
+  end
+
+  describe '.get' do
+    subject (:get) { client.get path, klass: klass }
+    it_behaves_like 'an account_name validator'
+  end
+
+  describe '.patch' do
+    subject (:patch) { client.patch path, klass: klass }
+    it_behaves_like 'an account_name validator'
+  end
+
+  describe '.post' do
+    subject (:post) { client.post path, klass: klass }
+    it_behaves_like 'an account_name validator'
+  end
+
+  describe '.put' do
+    subject (:put) { client.put path, klass: klass }
+    it_behaves_like 'an account_name validator'
+  end
+end


### PR DESCRIPTION
InvoiceXpress API docs mention an `account_name`, not a `screen_name`. This PR changes the config option to reflect the API docs.

Additionally, when this value is not set and a request is made, an inelegant and unclear Faraday error is raised. This PR also prevents that and suggests that an `account_name` be set.